### PR TITLE
modify(#24): 리프레시 토큰 response 값에 추가

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -59,7 +59,7 @@ export class AuthController {
       maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
     });
 
-    return res.json({ accessToken });
+    return res.json({ accessToken, refreshToken });
   }
 
   @ApiKakaoLogin()
@@ -88,7 +88,7 @@ export class AuthController {
       maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
     });
 
-    return res.json({ accessToken });
+    return res.json({ accessToken, refreshToken });
   }
 
   @ApiCookieAuth('refresh-token')

--- a/src/config/guards/jwt-refresh-token.guard.ts
+++ b/src/config/guards/jwt-refresh-token.guard.ts
@@ -7,7 +7,7 @@ export class JwtRefreshTokenGuard {
 
   async canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest();
-    const refreshToken = request.cookies['refresh_token'];
+    const refreshToken = request.headers['refresh_token'];
 
     if (!refreshToken) {
       return false;


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
리프레시 토큰을 로그인 api response 값에 추가했습니다. (https 설정 전까진 쿠키 사용이 안되기 때문)

| Method | Path | 설명 | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET | /auth/naver/login | 네이버 로그인 API | 수정 |
| GET | /auth/kakao/login | 카카오 로그인 API | 수정 |
