### PR TITLE
Feat/#30/redis 액세스 토큰 재발급 redis 사용

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -115,6 +115,8 @@ export class AuthController {
       socialRefreshToken,
     );
 
+    await this.redisService.setToken(String(userId), refreshToken);
+
     res.cookie('refresh_Token', refreshToken, {
       httpOnly: true,
       sameSite: 'Lax',

--- a/src/auth/services/token.service.ts
+++ b/src/auth/services/token.service.ts
@@ -129,12 +129,9 @@ export class TokenService {
       const userId = jwt.verify(token, jwtSecretKey)['userId'];
       const tokenType = jwt.verify(token, jwtSecretKey)['sub'];
       if (tokenType === 'refreshToken') {
-        // const userToken = await this.tokenRepository.getUserTokens(userId);
-        // const dbRefreshToken = userToken[0].refreshToken;
+        const rrt = await this.redisService.getToken(String(userId)); // RedisRefreshToken
 
-        const r = await this.redisService.getToken(String(userId));
-
-        if (token !== r) {
+        if (token !== rrt) {
           throw new HttpException(
             '토큰을 찾을 수 없습니다.',
             HttpStatus.NOT_FOUND,

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -11,14 +11,15 @@ import { MentorBoard } from './entities/mentor-board.entity';
 import { HelpMeBoardRepository } from './repository/help.me.board.repository';
 import { MentorBoardRepository } from './repository/mentor.boards.repository';
 import { BoardImageRepository } from './repository/boardImage.repository';
-import { TokenService } from 'src/auth/services/token.service';
-import { TokenRepository } from 'src/auth/repositories/token.repository';
 import { HelpMeBoardImage } from './entities/help-me-board-image.entity';
-import { RedisService } from 'src/common/redis/redis.service';
+import { RedisModule } from 'src/common/redis/redis.module';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MentorBoard, HelpMeBoard, HelpMeBoardImage]),
+    AuthModule,
+    RedisModule,
   ],
   controllers: [MentorBoardController, HelpMeBoardController],
   providers: [
@@ -26,12 +27,9 @@ import { RedisService } from 'src/common/redis/redis.service';
     MentorBoardService,
     BoardImagesService,
     S3Service,
-    TokenService,
     BoardImageRepository,
     HelpMeBoardRepository,
     MentorBoardRepository,
-    TokenRepository,
-    RedisService,
   ],
 })
 @Module({})

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -14,6 +14,7 @@ import { BoardImageRepository } from './repository/boardImage.repository';
 import { TokenService } from 'src/auth/services/token.service';
 import { TokenRepository } from 'src/auth/repositories/token.repository';
 import { HelpMeBoardImage } from './entities/help-me-board-image.entity';
+import { RedisService } from 'src/common/redis/redis.service';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { HelpMeBoardImage } from './entities/help-me-board-image.entity';
     HelpMeBoardRepository,
     MentorBoardRepository,
     TokenRepository,
+    RedisService,
   ],
 })
 @Module({})

--- a/src/comments/comment.module.ts
+++ b/src/comments/comment.module.ts
@@ -6,6 +6,7 @@ import { CommentsService } from './services/comments.services';
 import { TokenService } from 'src/auth/services/token.service';
 import { CommentsRepository } from './repository/comments.repository';
 import { TokenRepository } from 'src/auth/repositories/token.repository';
+import { RedisService } from 'src/common/redis/redis.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([HelpYouComment])],
@@ -15,6 +16,7 @@ import { TokenRepository } from 'src/auth/repositories/token.repository';
     CommentsRepository,
     TokenService,
     TokenRepository,
+    RedisService,
   ],
 })
 export class CommentModule {}

--- a/src/comments/comment.module.ts
+++ b/src/comments/comment.module.ts
@@ -6,17 +6,16 @@ import { CommentsService } from './services/comments.services';
 import { TokenService } from 'src/auth/services/token.service';
 import { CommentsRepository } from './repository/comments.repository';
 import { TokenRepository } from 'src/auth/repositories/token.repository';
-import { RedisService } from 'src/common/redis/redis.service';
+import { RedisModule } from 'src/common/redis/redis.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([HelpYouComment])],
+  imports: [TypeOrmModule.forFeature([HelpYouComment]), RedisModule],
   controllers: [CommentsController],
   providers: [
     CommentsService,
     CommentsRepository,
     TokenService,
     TokenRepository,
-    RedisService,
   ],
 })
 export class CommentModule {}

--- a/src/common/redis/redis.service.ts
+++ b/src/common/redis/redis.service.ts
@@ -9,7 +9,7 @@ export class RedisService {
     return this.cacheManager.get<string>(userId); // ? Retrieve data from the cache
   }
   async setToken(userId: string, token: string) {
-    await this.cacheManager.set(userId, token); //  ? Set data in the cache
+    await this.cacheManager.set(userId, token, 604800); //  ? Set data in the cache for 7 days
   }
 
   async delToken(userId: string) {

--- a/src/config/redis-options.constants.ts
+++ b/src/config/redis-options.constants.ts
@@ -12,7 +12,6 @@ export const RedisOptions: CacheModuleAsyncOptions = {
         host: process.env.REDIS_HOST,
         port: Number(process.env.REDIS_PORT),
       },
-      ttl: 604800, // 7일 (초 단위)
     });
     return {
       store: () => store,


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
액세스 토큰 재발급 redis 사용
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
로그인 -> 리프레시 토큰 redis에 저장 -> **액세스 토큰 재발급 시 redis에 저장한 리프레시 토큰 가져옴** -> 리프레시 토큰 비교

액세스 토큰 재발급 시 redis에 저장한 리프레시 토큰을 가져와서 재발급 하도록 수정했습니다.
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /auth/new-access-token | 액세스 토큰 재발급 | 수정 |
