### PR TITLE
feat(#76): 로그아웃, 회원탈퇴 구현

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -24,6 +24,9 @@ import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { JwtRefreshTokenGuard } from 'src/config/guards/jwt-refresh-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
 import { RedisService } from 'src/common/redis/redis.service';
+import { ApiGoogleLogin } from '../swagger-decorators/google-login.decorator';
+import { ApiGoogleLogout } from '../swagger-decorators/google-logout.decorator';
+import { ApiGoogleUnlink } from '../swagger-decorators/google-unlink.decorator';
 
 @Controller('auth')
 @ApiTags('auth API')
@@ -97,6 +100,7 @@ export class AuthController {
     return res.json({ accessToken, refreshToken });
   }
 
+  @ApiGoogleLogin()
   @Get('google/login')
   async googleLogin(@Query() { code }, @Res() res) {
     if (!code) {
@@ -182,12 +186,14 @@ export class AuthController {
     );
   }
 
+  @ApiGoogleLogout()
   @UseGuards(JwtAccessTokenGuard)
   @Post('google/logout')
   async googleLogout(@GetUserId() userId: number) {
     return await this.tokenService.deleteTokens(userId);
   }
 
+  @ApiGoogleUnlink()
   @UseGuards(JwtAccessTokenGuard)
   @Post('google/unlink')
   async googleUnlink(@GetUserId() userId: number) {

--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -182,6 +182,20 @@ export class AuthController {
     );
   }
 
+  @UseGuards(JwtAccessTokenGuard)
+  @Post('google/logout')
+  async googleLogout(@GetUserId() userId: number) {
+    return await this.tokenService.deleteTokens(userId);
+  }
+
+  @UseGuards(JwtAccessTokenGuard)
+  @Post('google/unlink')
+  async googleUnlink(@GetUserId() userId: number) {
+    const { socialAccessToken } = await this.tokenService.getUserTokens(userId);
+    await this.tokenService.deleteTokens(userId);
+    return await this.authService.googleUnlink(socialAccessToken);
+  }
+
   @ApiDeleteAccount()
   @UseGuards(JwtAccessTokenGuard)
   @Delete('account')

--- a/src/auth/interfaces/auth-service.interface.ts
+++ b/src/auth/interfaces/auth-service.interface.ts
@@ -1,8 +1,3 @@
 export interface AuthServiceInterface {
   login(authorizeCode: string, provider: string): Promise<any>;
-  unlink(
-    accessToken: string,
-    refreshToken: string,
-    provider: string,
-  ): Promise<any>;
 }

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -187,8 +187,6 @@ export class AuthService implements AuthServiceInterface {
     }
   }
 
-  async unlink(accessToken: string, refreshToken: string, provider: string) {}
-
   async kakaoLogout(accessToken: string, refreshToken: string) {
     try {
       const checkValidKakaoToken =
@@ -274,6 +272,20 @@ export class AuthService implements AuthServiceInterface {
       console.log(error);
       throw new HttpException(
         '네이버 연결 끊기 중 오류가 발생했습니다.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async googleUnlink(accessToken: string) {
+    try {
+      const googleUnlinkUrl = `https://accounts.google.com/o/oauth2/revoke?token=${accessToken}`;
+      axios.post(googleUnlinkUrl);
+      return { message: '구글 연결 끊기가 완료되었습니다.' };
+    } catch (error) {
+      console.log(error);
+      throw new HttpException(
+        '구글 연결 끊기 중 오류가 발생했습니다.',
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }

--- a/src/auth/swagger-decorators/google-login.decorator.ts
+++ b/src/auth/swagger-decorators/google-login.decorator.ts
@@ -1,0 +1,55 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGoogleLogin() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '구글 로그인 API',
+      description: '구글 로그인 API',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 로그인 된 경우 (refresh_token은 쿠키로 전달됨)',
+      content: {
+        JSON: {
+          example: {
+            accessToken: '여기에 액세스 토큰',
+            refreshToken: '여기에 리프레시 토큰',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '인가코드가 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            message: '인가코드가 없습니다.',
+            error: 'Bad Request',
+            statusCode: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '유효하지 않은 인가코드인 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 401,
+            message: '유효하지 않은 인가코드입니다.',
+          },
+        },
+      },
+    }),
+    ApiQuery({
+      name: 'code',
+      description: '구글 인가코드',
+      required: true,
+      example:
+        '4%2F0AfJohXmyKi4Zc9N6pddUKa7G__t7GLmsV2U4dLnb0xqM-sHaLl6NH32ZQEWUtUvHypPJxA',
+    }),
+  );
+}

--- a/src/auth/swagger-decorators/google-logout.decorator.ts
+++ b/src/auth/swagger-decorators/google-logout.decorator.ts
@@ -1,0 +1,74 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeaders, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGoogleLogout() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '구글 로그아웃 API',
+      description: '구글 로그아웃 API',
+    }),
+    ApiResponse({
+      status: 201,
+      description: '성공적으로 로그아웃 된 경우',
+      content: {
+        JSON: { example: { message: '구글 로그아웃이 완료되었습니다.' } },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '우리 서비스의 액세스 토큰이 아닌 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 401, message: '유효하지 않은 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '만료된 액세스 토큰인 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 403, message: '만료된 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'DB에서 구글 토큰을 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 404, message: '토큰을 찾을 수 없습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 411,
+      description: '액세스 토큰이 제공되지 않은 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 411, message: '토큰이 제공되지 않았습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 500,
+      description: '구글 로그아웃 API에서 오류가 발생한 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 500,
+            message: '구글 로그아웃 중 오류가 발생했습니다.',
+          },
+        },
+      },
+    }),
+    ApiHeaders([
+      {
+        name: 'access_token',
+        description: '액세스 토큰',
+        required: true,
+        example: '여기에 액세스 토큰',
+      },
+    ]),
+  );
+}

--- a/src/auth/swagger-decorators/google-unlink.decorator.ts
+++ b/src/auth/swagger-decorators/google-unlink.decorator.ts
@@ -1,0 +1,74 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeaders, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGoogleUnlink() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '구글 회원탈퇴 API',
+      description: '구글 회원탈퇴 API',
+    }),
+    ApiResponse({
+      status: 201,
+      description: '성공적으로 회원탈퇴 된 경우',
+      content: {
+        JSON: { example: { message: '구글 연결 끊기가 완료되었습니다.' } },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '우리 서비스의 액세스 토큰이 아닌 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 401, message: '유효하지 않은 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '만료된 액세스 토큰인 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 403, message: '만료된 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'DB에서 구글 토큰을 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 404, message: '토큰을 찾을 수 없습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 411,
+      description: '액세스 토큰이 제공되지 않은 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 411, message: '토큰이 제공되지 않았습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 500,
+      description: '구글 회원탈퇴 API에서 오류가 발생한 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 500,
+            message: '구글 연결 끊기 중 오류가 발생했습니다.',
+          },
+        },
+      },
+    }),
+    ApiHeaders([
+      {
+        name: 'access_token',
+        description: '액세스 토큰',
+        required: true,
+        example: '여기에 액세스 토큰',
+      },
+    ]),
+  );
+}

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3,8 +3,8 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 export function setupSwagger(app: INestApplication): void {
   const config = new DocumentBuilder()
-    .setTitle('ma6-main API')
-    .setDescription('모던애자일 6기 메인프로젝트 API 문서')
+    .setTitle('Menbosha API')
+    .setDescription('모던애자일 6기 멘보샤 프로젝트 API 문서')
     .setVersion('1.0')
     .addBearerAuth(
       {


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
oauth 로그아웃, 회원탈퇴 기능 구현
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
카카오, 네이버는 기존에 있던거 그대로 쓰고 구글 로그아웃, 회원탈퇴 기능을 추가했습니다.
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| POST    | /google/logout | 구글 로그아웃 | 추가                   |
| POST    | /google/unlink | 구글 회원탈퇴 | 추가                   |
