### PR TITLE
Feat/#92/user ranking total-ranking API return 값 수정

### DIFF
--- a/src/migrations/1705996137498-userRanking.ts
+++ b/src/migrations/1705996137498-userRanking.ts
@@ -1,0 +1,24 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableForeignKey,
+} from 'typeorm';
+
+export class UserRanking1705996137498 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createForeignKey(
+      'user_ranking',
+      new TableForeignKey({
+        columnNames: ['user_id'],
+        referencedTableName: 'user',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('user_ranking', 'user_id');
+  }
+}

--- a/src/migrations/1706015414954-modify-total-count-entity-name.ts
+++ b/src/migrations/1706015414954-modify-total-count-entity-name.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ModifyTotalCountEntityName1706015414954
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameColumn(
+      'total_count',
+      'mentor_board_count_7days',
+      'mentor_board_count_in_seven_days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'help_you_comment_count_7days',
+      'help_you_comment_count_in_seven_days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'mentor_board_like_count_7days',
+      'mentor_board_like_count_in_seven_days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'badge_count_7days',
+      'badge_count_in_seven_days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'review_count_7days',
+      'review_count_in_seven_days',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameColumn(
+      'total_count',
+      'mentor_board_count_in_seven_days',
+      'mentor_board_count_7days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'help_you_comment_count_in_seven_days',
+      'help_you_comment_count_7days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'mentor_board_like_count_in_seven_days',
+      'mentor_board_like_count_7days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'badge_count_in_seven_days',
+      'badge_count_7days',
+    );
+    await queryRunner.renameColumn(
+      'total_count',
+      'review_count_in_seven_days',
+      'review_count_7days',
+    );
+  }
+}

--- a/src/total-count/entities/total-count.entity.ts
+++ b/src/total-count/entities/total-count.entity.ts
@@ -30,20 +30,20 @@ export class TotalCount {
   @Column({ name: 'review_count', default: 0 })
   reviewCount: number;
 
-  @Column({ name: 'mentor_board_count_7days', default: 0 })
-  mentorBoardCount7days: number;
+  @Column({ name: 'mentor_board_count_in_seven_days', default: 0 })
+  mentorBoardCountInSevenDays: number;
 
-  @Column({ name: 'help_you_comment_count_7days', default: 0 })
-  helpYouCommentCount7days: number;
+  @Column({ name: 'help_you_comment_count_in_seven_days', default: 0 })
+  helpYouCommentCountInSevenDays: number;
 
-  @Column({ name: 'mentor_board_like_count_7days', default: 0 })
-  mentorBoardLikeCount7days: number;
+  @Column({ name: 'mentor_board_like_count_in_seven_days', default: 0 })
+  mentorBoardLikeCountInSevenDays: number;
 
-  @Column({ name: 'badge_count_7days', default: 0 })
-  badgeCount7days: number;
+  @Column({ name: 'badge_count_in_seven_days', default: 0 })
+  badgeCountInSevenDays: number;
 
-  @Column({ name: 'review_count_7days', default: 0 })
-  reviewCount7days: number;
+  @Column({ name: 'review_count_in_seven_days', default: 0 })
+  reviewCountInSevenDays: number;
 
   @OneToOne(() => User, (userId: User) => userId.id, {
     onDelete: 'CASCADE',

--- a/src/total-count/repositories/total-count.repository.ts
+++ b/src/total-count/repositories/total-count.repository.ts
@@ -18,7 +18,7 @@ export class TotalCountRepository {
       await this.entityManager.increment(
         TotalCount,
         { userId },
-        `${type}7days`,
+        `${type}InSevenDays`,
         1,
       );
     } else {
@@ -26,7 +26,7 @@ export class TotalCountRepository {
       await this.entityManager.decrement(
         TotalCount,
         { userId },
-        `${type}7days`,
+        `${type}InSevenDays`,
         1,
       );
     }
@@ -37,11 +37,11 @@ export class TotalCountRepository {
       TotalCount,
       {},
       {
-        mentorBoardCount7days: 0,
-        helpYouCommentCount7days: 0,
-        mentorBoardLikeCount7days: 0,
-        badgeCount7days: 0,
-        reviewCount7days: 0,
+        mentorBoardCountInSevenDays: 0,
+        helpYouCommentCountInSevenDays: 0,
+        mentorBoardLikeCountInSevenDays: 0,
+        badgeCountInSevenDays: 0,
+        reviewCountInSevenDays: 0,
       },
     );
   }

--- a/src/users/dtos/response-user-ranking.dto.ts
+++ b/src/users/dtos/response-user-ranking.dto.ts
@@ -48,4 +48,16 @@ export class ResponseUserRankingDto {
     example: 3,
   })
   reviewCount: number;
+
+  @ApiProperty({
+    description: '멘토 게시글 수',
+    example: 2,
+  })
+  mentorBoardCount: number;
+
+  @ApiProperty({
+    description: '유저 프로필 이미지',
+    example: 'https://image.com',
+  })
+  imageUrl: string;
 }

--- a/src/users/dtos/user-info.dto.ts
+++ b/src/users/dtos/user-info.dto.ts
@@ -17,6 +17,7 @@ export class UserInfoDto
       | 'categoryList'
       | 'totalCount'
       | 'mentorBoardLikes'
+      | 'userRanking'
     >
 {
   @ApiProperty({

--- a/src/users/entities/user-ranking.entity.ts
+++ b/src/users/entities/user-ranking.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from './user.entity';
 
 @Entity({ name: 'user_ranking' })
 export class UserRanking {
@@ -28,4 +35,10 @@ export class UserRanking {
 
   @Column({ name: 'review_count', nullable: true })
   reviewCount: number | null;
+
+  @ManyToOne(() => User, (userId: User) => userId.userRanking, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -18,6 +18,7 @@ import { CategoryList } from '../../category/entity/category-list.entity';
 import { UserIntro } from './user-intro.entity';
 import { TotalCount } from 'src/total-count/entities/total-count.entity';
 import { MentorBoardLike } from 'src/boards/entities/mentor-board-like.entity';
+import { UserRanking } from './user-ranking.entity';
 
 @Entity({
   name: 'user',
@@ -94,4 +95,9 @@ export class User {
     onDelete: 'CASCADE',
   })
   totalCount: TotalCount;
+
+  @OneToMany(() => UserRanking, (userRanking) => userRanking.user, {
+    onDelete: 'CASCADE',
+  })
+  userRanking: UserRanking;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -82,22 +82,16 @@ export class User {
   @JoinColumn({ name: 'user_badge_id' })
   userBadge: UserBadge;
 
-  @OneToOne(() => Token, (token) => token.user, {
-    onDelete: 'CASCADE',
-  })
+  @OneToOne(() => Token, (token) => token.user)
   token: Token;
 
   @ManyToMany(() => CategoryList, (categoryList) => categoryList.user)
   @JoinColumn({ name: 'category_id' })
   categoryList: CategoryList;
 
-  @OneToOne(() => TotalCount, (totalcount) => totalcount.user, {
-    onDelete: 'CASCADE',
-  })
+  @OneToOne(() => TotalCount, (totalcount) => totalcount.user)
   totalCount: TotalCount;
 
-  @OneToMany(() => UserRanking, (userRanking) => userRanking.user, {
-    onDelete: 'CASCADE',
-  })
+  @OneToMany(() => UserRanking, (userRanking) => userRanking.user)
   userRanking: UserRanking;
 }

--- a/src/users/repositories/user-ranking.repository.ts
+++ b/src/users/repositories/user-ranking.repository.ts
@@ -37,17 +37,17 @@ export class UserRankingRepository {
     const allCounts = await this.entityManager.find(TotalCount, {
       select: [
         'userId',
-        'mentorBoardCount7days',
-        'mentorBoardLikeCount7days',
-        'helpYouCommentCount7days',
-        'badgeCount7days',
-        'reviewCount7days',
+        'mentorBoardCountInSevenDays',
+        'mentorBoardLikeCountInSevenDays',
+        'helpYouCommentCountInSevenDays',
+        'badgeCountInSevenDays',
+        'reviewCountInSevenDays',
       ],
       where: [
-        { mentorBoardCount7days: MoreThanOrEqual(2) },
-        { helpYouCommentCount7days: MoreThanOrEqual(3) },
-        { mentorBoardLikeCount7days: MoreThanOrEqual(6) },
-        { reviewCount7days: MoreThanOrEqual(1) },
+        { mentorBoardCountInSevenDays: MoreThanOrEqual(2) },
+        { helpYouCommentCountInSevenDays: MoreThanOrEqual(3) },
+        { mentorBoardLikeCountInSevenDays: MoreThanOrEqual(6) },
+        { reviewCountInSevenDays: MoreThanOrEqual(1) },
       ],
     });
 

--- a/src/users/repositories/user-ranking.repository.ts
+++ b/src/users/repositories/user-ranking.repository.ts
@@ -94,4 +94,12 @@ export class UserRankingRepository {
       .where('userId = :userId', { userId })
       .execute();
   }
+
+  async clearUserRanking() {
+    return await this.entityManager
+      .createQueryBuilder()
+      .delete()
+      .from(UserRanking)
+      .execute();
+  }
 }

--- a/src/users/repositories/user-ranking.repository.ts
+++ b/src/users/repositories/user-ranking.repository.ts
@@ -4,25 +4,33 @@ import { User } from '../entities/user.entity';
 import { TotalCount } from 'src/total-count/entities/total-count.entity';
 import { UserRanking } from '../entities/user-ranking.entity';
 import { UserIntro } from '../entities/user-intro.entity';
+import { UserImage } from '../entities/user-image.entity';
 
 @Injectable()
 export class UserRankingRepository {
   constructor(private readonly entityManager: EntityManager) {}
 
   async getUserRanking() {
-    return await this.entityManager.find(UserRanking, {
-      select: [
-        'userId',
-        'activityCategoryId',
-        'name',
-        'rank',
-        'reviewCount',
-        'mainField',
-        'career',
-        'introduce',
-      ],
-      take: 10,
-    });
+    return await this.entityManager
+      .createQueryBuilder(UserRanking, 'userRanking')
+      .leftJoin(User, 'user', 'user.id = userRanking.userId')
+      .leftJoin(UserImage, 'userImage', 'user.id = userImage.userId')
+      .leftJoin(TotalCount, 'totalCount', 'user.id = totalCount.userId')
+      .select([
+        'userRanking.userId as userId',
+        'userRanking.name as `name`',
+        'userRanking.rank as `rank`',
+        'userRanking.mainField as mainField',
+        'userRanking.introduce as introduce',
+        'userRanking.career as career',
+        'userRanking.activityCategoryId as activityCategoryId',
+        'userImage.imageUrl as imageUrl',
+        'totalCount.reviewCount as reviewCount',
+        'totalCount.mentorBoardCount as mentorBoardCount',
+      ])
+      .distinct(true)
+      .take(10)
+      .getRawMany();
   }
 
   async allUserCounts() {

--- a/src/users/services/user-ranking.service.ts
+++ b/src/users/services/user-ranking.service.ts
@@ -26,22 +26,22 @@ export class UserRankingService {
       const userRankingArray = allUserCounts
         .map((user) => {
           let totalScore =
-            user.mentorBoardCount7days * 23 +
-            user.mentorBoardLikeCount7days * 10 +
-            user.helpYouCommentCount7days * 7 +
-            user.reviewCount7days * 97 +
-            user.badgeCount7days * 18;
+            user.mentorBoardCountInSevenDays * 23 +
+            user.mentorBoardLikeCountInSevenDays * 10 +
+            user.helpYouCommentCountInSevenDays * 7 +
+            user.reviewCountInSevenDays * 97 +
+            user.badgeCountInSevenDays * 18;
 
-          if (user.mentorBoardCount7days > 10) {
-            const after = user.mentorBoardCount7days - 10;
+          if (user.mentorBoardCountInSevenDays > 10) {
+            const after = user.mentorBoardCountInSevenDays - 10;
             totalScore = totalScore - after * 13;
           }
-          if (user.helpYouCommentCount7days > 20) {
-            const after = user.helpYouCommentCount7days - 20;
+          if (user.helpYouCommentCountInSevenDays > 20) {
+            const after = user.helpYouCommentCountInSevenDays - 20;
             totalScore = totalScore - after * 4;
           }
-          if (user.reviewCount7days > 5) {
-            const after = user.reviewCount7days - 5;
+          if (user.reviewCountInSevenDays > 5) {
+            const after = user.reviewCountInSevenDays - 5;
             totalScore = totalScore + after * 49;
           }
           if (totalScore < 60) {

--- a/src/users/services/user-ranking.service.ts
+++ b/src/users/services/user-ranking.service.ts
@@ -78,4 +78,18 @@ export class UserRankingService {
       );
     }
   }
+
+  @Cron('0 58 8 * * 1') // 매주 월요일 오전 8시 58분에 실행 (유저 랭킹 저장 전에 실행)
+  async clearUserRanking() {
+    try {
+      await this.userRankingRepository.clearUserRanking();
+      return { message: '랭킹 초기화 성공' };
+    } catch (error) {
+      console.log(error);
+      throw new HttpException(
+        '랭킹 초기화 중 에러가 발생했습니다.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
 }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
프론트 요청에 따라 total-ranking API return 값에 유저 프로필 이미지와 멘토 게시글 개수를 추가했습니다.

total-count 테이블의 칼럼명을 수정했습니다.

유저 랭킹 데이터 저장 전에 랭킹 테이블 초기화 스케줄러 적용했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
마이그레이션을 사용해서 user_ranking 테이블에 user_id FK키 설정 했습니다.
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#92 
<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /user/total-ranking | 전체 유저 랭킹 조회 | 수정                   |
