### PR TITLE
feat(#92): swagger authorization 기능 추가

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -12,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { S3Service } from 'src/common/s3/s3.service';
 import { TokenService } from '../services/token.service';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiTags } from '@nestjs/swagger';
 import { ApiNaverLogin } from '../swagger-decorators/naver-login.decorator';
 import { ApiKakaoLogin } from '../swagger-decorators/kakao-login.decorator';
 import { ApiNewAccessToken } from '../swagger-decorators/new-access-token.decorator';
@@ -141,6 +141,7 @@ export class AuthController {
     return res.json({ accessToken: newAccessToken });
   }
 
+  @ApiBearerAuth('access-token')
   @ApiKakaoLogout()
   @UseGuards(JwtAccessTokenGuard)
   @Post('kakao/logout')
@@ -154,6 +155,7 @@ export class AuthController {
     );
   }
 
+  @ApiBearerAuth('access-token')
   @ApiKakaoUnlink()
   @UseGuards(JwtAccessTokenGuard)
   @Post('kakao/unlink')
@@ -167,6 +169,7 @@ export class AuthController {
     );
   }
 
+  @ApiBearerAuth('access-token')
   @ApiNaverLogout()
   @UseGuards(JwtAccessTokenGuard)
   @Post('naver/logout')
@@ -174,6 +177,7 @@ export class AuthController {
     return await this.tokenService.deleteTokens(userId);
   }
 
+  @ApiBearerAuth('access-token')
   @ApiNaverUnlink()
   @UseGuards(JwtAccessTokenGuard)
   @Post('naver/unlink')
@@ -187,6 +191,7 @@ export class AuthController {
     );
   }
 
+  @ApiBearerAuth('access-token')
   @ApiGoogleLogout()
   @UseGuards(JwtAccessTokenGuard)
   @Post('google/logout')
@@ -194,6 +199,7 @@ export class AuthController {
     return await this.tokenService.deleteTokens(userId);
   }
 
+  @ApiBearerAuth('access-token')
   @ApiGoogleUnlink()
   @UseGuards(JwtAccessTokenGuard)
   @Post('google/unlink')
@@ -203,6 +209,7 @@ export class AuthController {
     return await this.authService.googleUnlink(socialAccessToken);
   }
 
+  @ApiBearerAuth('access-token')
   @ApiDeleteAccount()
   @UseGuards(JwtAccessTokenGuard)
   @Delete('account')

--- a/src/auth/swagger-decorators/delete-account.decorator.ts
+++ b/src/auth/swagger-decorators/delete-account.decorator.ts
@@ -68,7 +68,6 @@ export function ApiDeleteAccount() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/auth/swagger-decorators/google-logout.decorator.ts
+++ b/src/auth/swagger-decorators/google-logout.decorator.ts
@@ -79,7 +79,6 @@ export function ApiGoogleLogout() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/auth/swagger-decorators/google-unlink.decorator.ts
+++ b/src/auth/swagger-decorators/google-unlink.decorator.ts
@@ -79,7 +79,6 @@ export function ApiGoogleUnlink() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/auth/swagger-decorators/kakao-logout.decorator.ts
+++ b/src/auth/swagger-decorators/kakao-logout.decorator.ts
@@ -79,7 +79,6 @@ export function ApiKakaoLogout() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/auth/swagger-decorators/kakao-unlink.decorator.ts
+++ b/src/auth/swagger-decorators/kakao-unlink.decorator.ts
@@ -79,7 +79,6 @@ export function ApiKakaoUnlink() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/auth/swagger-decorators/naver-logout.decorator.ts
+++ b/src/auth/swagger-decorators/naver-logout.decorator.ts
@@ -65,7 +65,6 @@ export function ApiNaverLogout() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/auth/swagger-decorators/naver-unlink.decorator.ts
+++ b/src/auth/swagger-decorators/naver-unlink.decorator.ts
@@ -79,7 +79,6 @@ export function ApiNaverUnlink() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/auth/swagger-decorators/new-access-token.decorator.ts
+++ b/src/auth/swagger-decorators/new-access-token.decorator.ts
@@ -66,7 +66,6 @@ export function ApiNewAccessToken() {
       {
         name: 'refresh_token',
         description: '리프레시 토큰',
-        required: true,
         example: '여기에 리프레시 토큰',
       },
     ]),

--- a/src/config/guards/jwt-access-token.guard.ts
+++ b/src/config/guards/jwt-access-token.guard.ts
@@ -7,7 +7,12 @@ export class JwtAccessTokenGuard {
 
   async canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest();
-    const accessToken = request.headers['access_token'];
+    const authorization = request.headers['authorization'];
+
+    const [type, accessToken] = authorization.split(' ');
+    if (type !== 'Bearer') {
+      return false;
+    }
 
     const userId = await this.tokenService.decodeToken(accessToken);
     request.user = { userId };

--- a/src/config/guards/jwt-refresh-token.guard.ts
+++ b/src/config/guards/jwt-refresh-token.guard.ts
@@ -7,9 +7,10 @@ export class JwtRefreshTokenGuard {
 
   async canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest();
-    const refreshToken = request.headers['refresh_token'];
+    const authorization = request.headers['authorization'];
 
-    if (!refreshToken) {
+    const [type, refreshToken] = authorization.split(' ');
+    if (type !== 'Bearer') {
       return false;
     }
 

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -12,7 +12,7 @@ export function setupSwagger(app: INestApplication): void {
         scheme: 'bearer',
         bearerFormat: 'JWT',
         name: 'JWT',
-        description: '여기에 토큰 입력',
+        description: '액세스 토큰 입력',
         in: 'header',
       },
       'access-token',
@@ -23,7 +23,7 @@ export function setupSwagger(app: INestApplication): void {
         type: 'http',
         in: 'Header',
         scheme: 'Bearer',
-        description: '여기에 토큰 입력',
+        description: '리프레시 토큰 입력',
       },
       'refresh-token',
     )

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { setupSwagger } from './config/swagger';
-import { AsyncApiDocumentBuilder, AsyncApiModule } from 'nestjs-asyncapi';
 import * as cookieParser from 'cookie-parser';
 // import { HttpBadRequestExceptionFilter } from './http-exceptions/exception-filters/http-bad-request-exception.filter';
 // import { HttpProcessErrorExceptionFilter } from './http-exceptions/exception-filters/http-process-error-exception.filter';
@@ -25,18 +24,6 @@ async function bootstrap() {
   });
   app.use(cookieParser());
   setupSwagger(app);
-  const asyncApiOptions = new AsyncApiDocumentBuilder()
-    .setTitle('ma6-main-asyncapi')
-    .setDescription('모던애자일 6기 메인프로젝트 AsyncAPI 문서')
-    .setVersion('1.0')
-    .setDefaultContentType('application/json')
-    .build();
-
-  const asyncApiDocument = await AsyncApiModule.createDocument(
-    app,
-    asyncApiOptions,
-  );
-  await AsyncApiModule.setup('asyncapi', app, asyncApiDocument);
   app.useLogger(logger);
 
   // app.useGlobalFilters(

--- a/src/total-count/controllers/total-count.controller.ts
+++ b/src/total-count/controllers/total-count.controller.ts
@@ -6,13 +6,14 @@ import { Type } from '../enums/type.enum';
 import { UpdateCountingDto } from '../dtos/update-counting.dto';
 import { Action } from '../enums/action.enum';
 import { ApiCounting } from '../swagger-decorators/counting.decorator';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
 @Controller('total-count')
 @ApiTags('total-count API')
 export class TotalCountController {
   constructor(private readonly totalCountService: TotalCountService) {}
 
+  @ApiBearerAuth('access-token')
   @ApiCounting()
   @UseGuards(JwtAccessTokenGuard)
   @Patch('/counting')

--- a/src/total-count/swagger-decorators/counting.decorator.ts
+++ b/src/total-count/swagger-decorators/counting.decorator.ts
@@ -53,7 +53,6 @@ export function ApiCounting() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/users/controllers/user-image.controller.ts
+++ b/src/users/controllers/user-image.controller.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UserImageService } from '../services/user-image.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { ApiUpdateUserImage } from '../swagger-decorators/update-user-image.decorator';
 import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
@@ -17,6 +17,7 @@ import { GetUserId } from 'src/common/decorators/get-userId.decorator';
 export class UserImageController {
   constructor(private readonly userImageService: UserImageService) {}
 
+  @ApiBearerAuth('access-token')
   @ApiUpdateUserImage()
   @UseGuards(JwtAccessTokenGuard)
   @Patch()

--- a/src/users/controllers/user.controller.ts
+++ b/src/users/controllers/user.controller.ts
@@ -12,7 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { UserService } from '../services/user.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
 import { ApiGetMyProfile } from '../swagger-decorators/get-my-profile-decorator';
@@ -30,7 +30,6 @@ import { ApiUpdateUserIntro } from '../swagger-decorators/patch-user-intro-decor
 import { ApiGetMyRank } from '../swagger-decorators/get-my-rank-decorators';
 import { ApiGetUserInfo } from '../swagger-decorators/get-user-info.decorators';
 import { UserRankingService } from '../services/user-ranking.service';
-import { TotalCountService } from 'src/total-count/services/total-count.service';
 import { UserBadgeService } from '../services/user-badge.service';
 import { ApiGetTotalRanking } from '../swagger-decorators/get-total-ranking.decorator';
 
@@ -45,6 +44,7 @@ export class UserController {
     private readonly userBadgeService: UserBadgeService,
   ) {}
 
+  @ApiBearerAuth('access-token')
   @ApiGetMyProfile()
   @UseGuards(JwtAccessTokenGuard)
   @Get('my/profile')
@@ -52,6 +52,7 @@ export class UserController {
     return this.userService.getMyProfile(userId);
   }
 
+  @ApiBearerAuth('access-token')
   @ApiGetMyRank()
   @UseGuards(JwtAccessTokenGuard)
   @Get('my/rank')
@@ -65,6 +66,7 @@ export class UserController {
     return this.userService.getUserInfo(userId);
   }
 
+  @ApiBearerAuth('access-token')
   @UseGuards(JwtAccessTokenGuard)
   @ApiGetMyInfoWithOwner()
   @Get('my-info/:targetId')
@@ -97,6 +99,7 @@ export class UserController {
     return this.userRankingService.getUserRanking();
   }
 
+  @ApiBearerAuth('access-token')
   @UseGuards(JwtAccessTokenGuard)
   @ApiPostUserIntro()
   @Post('/intro')
@@ -107,6 +110,7 @@ export class UserController {
     return this.userIntroService.addUserIntro(userId, userData);
   }
 
+  @ApiBearerAuth('access-token')
   @UseGuards(JwtAccessTokenGuard)
   @ApiUpdateUserIntro()
   @Patch('/intro')
@@ -117,6 +121,7 @@ export class UserController {
     return this.userIntroService.updateUserIntro(userId, userData);
   }
 
+  @ApiBearerAuth('access-token')
   @UseGuards(JwtAccessTokenGuard)
   @Get('/badge')
   getBadge(@GetUserId() userId: number) {

--- a/src/users/swagger-decorators/get-my-info-with-owner-decorator.ts
+++ b/src/users/swagger-decorators/get-my-info-with-owner-decorator.ts
@@ -47,7 +47,6 @@ export function ApiGetMyInfoWithOwner() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/users/swagger-decorators/get-my-profile-decorator.ts
+++ b/src/users/swagger-decorators/get-my-profile-decorator.ts
@@ -44,13 +44,13 @@ export function ApiGetMyProfile() {
         },
       },
     }),
-    ApiHeaders([
-      {
-        name: 'access_token',
-        description: '액세스 토큰',
-        required: true,
-        example: '여기에 액세스 토큰',
-      },
-    ]),
+    // ApiHeaders([
+    //   {
+    //     name: 'access_token',
+    //     description: '액세스 토큰',
+    //     required: true,
+    //     example: '여기에 액세스 토큰',
+    //   },
+    // ]),
   );
 }

--- a/src/users/swagger-decorators/get-my-profile-decorator.ts
+++ b/src/users/swagger-decorators/get-my-profile-decorator.ts
@@ -44,13 +44,12 @@ export function ApiGetMyProfile() {
         },
       },
     }),
-    // ApiHeaders([
-    //   {
-    //     name: 'access_token',
-    //     description: '액세스 토큰',
-    //     required: true,
-    //     example: '여기에 액세스 토큰',
-    //   },
-    // ]),
+    ApiHeaders([
+      {
+        name: 'access_token',
+        description: '액세스 토큰',
+        example: '여기에 액세스 토큰',
+      },
+    ]),
   );
 }

--- a/src/users/swagger-decorators/patch-user-intro-decorator.ts
+++ b/src/users/swagger-decorators/patch-user-intro-decorator.ts
@@ -85,7 +85,6 @@ export function ApiUpdateUserIntro() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/users/swagger-decorators/update-user-image.decorator.ts
+++ b/src/users/swagger-decorators/update-user-image.decorator.ts
@@ -79,7 +79,6 @@ export function ApiUpdateUserImage() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/src/users/swagger-decorators/upload-user-Intro-decorators.ts
+++ b/src/users/swagger-decorators/upload-user-Intro-decorators.ts
@@ -85,7 +85,6 @@ export function ApiPostUserIntro() {
       {
         name: 'access_token',
         description: '액세스 토큰',
-        required: true,
         example: '여기에 액세스 토큰',
       },
     ]),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
-  }
+    "noFallthroughCasesInSwitch": false,
+  },
 }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
swagger authorization 기능 추가
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
액세스 토큰을 사용하는 API 컨트롤러 위에
`@ApiBearerAuth('access-token')`
추가해주시면 됩니다.

API 명세서에선 ApiHeaders에 required: true 옵션 지워주셔야 통합 인증이 가능합니다!
(required: true로 되어있으면 따로 헤더에 토큰값 입력해줘야 함)
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link
https://blog.naver.com/PostView.naver?blogId=terry0222&logNo=223019316605
<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#92 
