### PR TITLE
Modify/#147/mongoose transaction

### DIFF
--- a/src/chat/dto/chat-room.dto.ts
+++ b/src/chat/dto/chat-room.dto.ts
@@ -62,10 +62,6 @@ export class ChatRoomDto implements Omit<ChatRooms, 'unprotectedData'> {
   @Expose()
   updatedAt: Date;
 
-  @ApiProperty({
-    description: '채팅방 삭제 날짜',
-    default: null,
-  })
   @Exclude()
   deletedAt: Date | null;
 

--- a/src/chat/dto/chat.dto.ts
+++ b/src/chat/dto/chat.dto.ts
@@ -51,13 +51,8 @@ export class ChatDto implements Chat {
   @Expose()
   createdAt: Date;
 
-  @ApiProperty({
-    description: '채팅 삭제 날짜',
-    type: 'string',
-    format: 'date-time',
-  })
-  @Exclude()
-  deletedAt: Date;
+  @Exclude({ toPlainOnly: true })
+  deletedAt: Date | null;
 
   constructor(chatDto: Partial<ChatDto> = {}) {
     this._id = chatDto._id;
@@ -66,5 +61,6 @@ export class ChatDto implements Chat {
     this.senderId = chatDto.senderId;
     this.seenUsers = chatDto.seenUsers;
     this.createdAt = chatDto.createdAt;
+    this.deletedAt = chatDto.deletedAt;
   }
 }

--- a/src/chat/schemas/chat-rooms.schemas.ts
+++ b/src/chat/schemas/chat-rooms.schemas.ts
@@ -3,6 +3,7 @@ import { Chat } from './chats.schemas';
 import mongoose from 'mongoose';
 import { ChatRoomType } from '../constants/chat-rooms-enum';
 import * as mongoosePaginate from 'mongoose-paginate-v2';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const aggregatePaginate = require('mongoose-aggregate-paginate-v2');
 
 const options: SchemaOptions = {

--- a/src/chat/services/chat.service.ts
+++ b/src/chat/services/chat.service.ts
@@ -505,10 +505,10 @@ export class ChatService {
 
     if (
       !existChatRoom.chats.length ||
-      !existChatRoom.chats.find((chat: ChatDto) => {
-        console.log(chat);
-        return chat._id === chatId && chat.senderId === myId && !chat.deletedAt;
-      })
+      !existChatRoom.chats.find(
+        (chat: ChatDto) =>
+          chat._id === chatId && chat.senderId === myId && !chat.deletedAt,
+      )
     ) {
       throw new NotFoundException('해당 채팅이 존재하지 않습니다.');
     }

--- a/src/chat/services/chat.service.ts
+++ b/src/chat/services/chat.service.ts
@@ -506,11 +506,8 @@ export class ChatService {
     if (
       !existChatRoom.chats.length ||
       !existChatRoom.chats.find((chat: ChatDto) => {
-        return (
-          chat._id === chatId &&
-          chat.senderId === myId &&
-          chat.deletedAt === null
-        );
+        console.log(chat);
+        return chat._id === chatId && chat.senderId === myId && !chat.deletedAt;
       })
     ) {
       throw new NotFoundException('해당 채팅이 존재하지 않습니다.');

--- a/src/chat/services/chat.service.ts
+++ b/src/chat/services/chat.service.ts
@@ -505,7 +505,7 @@ export class ChatService {
 
     if (
       !existChatRoom.chats.length ||
-      !existChatRoom.chats.find(
+      !existChatRoom.chats.some(
         (chat: ChatDto) =>
           chat._id === chatId && chat.senderId === myId && !chat.deletedAt,
       )


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
생각해보니까 트랜잭션으로 묶어야 되는 작업이 아니라 트랜잭션으로 묶지는 않았습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
대신 문제가 있었던 코드를 수정했습니다. 
채팅을 조회하는 코드에서 채팅 읽음 처리를 하고 그 업데이트된 값을 불러오기 위해 업데이트를 먼저 하고 조회하는 괴상한 패턴이 있었습니다.
채팅을 먼저 조회해서 문제가 없는지 확인 - 채팅 읽음 처리를 위해 업데이트 - 업데이트가 잘되면 클라이언트 측에는 업데이트된 값을 보여줘야 하기 때문에 채팅을 다시 불러옴.
이게 너무 네트워크 비용 낭비가 있는 것 같아서 그냥 업데이트 때려박고 조회를 했었는데
아무리 생각해도 좀 아닌 것 같아서 
조회 
업데이트
업데이트 됐다고 가정하고 이미 조회한 값을 직접 바꿔줌
- DB 부하 줄임
- 네트워크 비용 줄임
으로 로직이 변경 됐습니다.
어차피 클라이언트 측에 deletedAt 프로퍼티를 노출하지 않기 때문에 문서에서 정의할 필요도 없다고 생각돼서 해당하는 코드도 수정했습니다. 
추가로 채팅 삭제 로직에서도 문제가 있던 부분을 수정했습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#147 

<!-- 작업한 API (선택) -->
### API
