### PR TITLE
modify(#160): 리프레시 토큰 에러 핸들링 수정

### DIFF
--- a/src/auth/services/token.service.ts
+++ b/src/auth/services/token.service.ts
@@ -133,21 +133,22 @@ export class TokenService {
 
         if (token !== rrt) {
           throw new HttpException(
-            '토큰을 찾을 수 없습니다.',
-            HttpStatus.NOT_FOUND,
+            'token not found in redis',
+            HttpStatus.UNAUTHORIZED,
           );
         }
       }
       return { message: '유효한 토큰입니다.' };
     } catch (error) {
       if (
-        error.message == 'jwt expired' ||
-        error.message == 'invalid signature'
+        error.message === 'jwt expired' ||
+        error.message === 'invalid signature' ||
+        error.message === 'token not found in redis'
       ) {
         throw new HttpException(error.message, HttpStatus.UNAUTHORIZED);
       } else if (
-        error.message == 'invalid token' ||
-        error.message == 'jwt must be provided'
+        error.message === 'invalid token' ||
+        error.message === 'jwt must be provided'
       ) {
         throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
       } else {

--- a/src/auth/swagger-decorators/new-access-token.decorator.ts
+++ b/src/auth/swagger-decorators/new-access-token.decorator.ts
@@ -54,16 +54,14 @@ export function ApiNewAccessToken() {
               value: { statusCode: 401, message: 'jwt expired' },
               description: '만료된 토큰인 경우',
             },
+            'token not found in redis': {
+              value: {
+                statusCode: 401,
+                message: 'token not found in redis',
+              },
+              description: '리프레시 토큰이 Redis에 없는 경우',
+            },
           },
-        },
-      },
-    }),
-    ApiResponse({
-      status: 404,
-      description: '리프레시 토큰을 DB에서 찾을 수 없는 경우',
-      content: {
-        JSON: {
-          example: { statusCode: 404, message: '토큰을 찾을 수 없습니다.' },
         },
       },
     }),


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
리프레시 토큰 에러 핸들링 수정
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
리프레시 토큰을 redis에서 찾을 수 없는 경우,
```
{
    "statusCode": 401,
    "message": "token not found in redis"
}
```
위 에러가 리턴됩니다.
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#160 
