### PR TITLE
Feat/#185/create custom validator

### DIFF
--- a/src/common/decorators/validators/is-not-empty-object-and-all-false.decorator.ts
+++ b/src/common/decorators/validators/is-not-empty-object-and-all-false.decorator.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { applyDecorators } from '@nestjs/common';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmptyObject,
+  ValidationArguments,
+  ValidationOptions,
+  registerDecorator,
+} from 'class-validator';
+
+export function IsNotEmptyObjectAndAllFalse(
+  options?: { nullable: boolean },
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: any, propertyName: string) {
+    IsNotEmptyObject(options, validationOptions)(object, propertyName);
+    registerDecorator({
+      name: 'isNotEmptyObjectAndAllFalse',
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [],
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          for (const key in value) {
+            if (value[key]) {
+              return true;
+            }
+          }
+
+          return false;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return 'At least one property in createMentorReviewChecklistRequestBodyDto should be true.';
+        },
+      },
+    });
+  };
+}

--- a/src/common/decorators/validators/is-not-empty-object-and-all-false.decorator.ts
+++ b/src/common/decorators/validators/is-not-empty-object-and-all-false.decorator.ts
@@ -12,7 +12,7 @@ export function IsNotEmptyObjectAndAllFalse(
   options?: { nullable: boolean },
   validationOptions?: ValidationOptions,
 ) {
-  return function (object: { key: boolean }, propertyName: string) {
+  return function (object: Record<string, any>, propertyName: string) {
     IsNotEmptyObject(options, validationOptions)(object, propertyName);
     registerDecorator({
       name: 'isNotEmptyObjectAndAllFalse',
@@ -22,16 +22,10 @@ export function IsNotEmptyObjectAndAllFalse(
       options: validationOptions,
       validator: {
         validate(value: any, args: ValidationArguments) {
-          for (const key in value) {
-            if (value[key]) {
-              return true;
-            }
-          }
-
-          return false;
+          return Object.values(value).some((value) => value);
         },
         defaultMessage(args: ValidationArguments) {
-          return 'At least one property in createMentorReviewChecklistRequestBodyDto should be true.';
+          return 'At least one property in $property should be true.';
         },
       },
     });

--- a/src/common/decorators/validators/is-not-empty-object-and-all-false.decorator.ts
+++ b/src/common/decorators/validators/is-not-empty-object-and-all-false.decorator.ts
@@ -12,7 +12,7 @@ export function IsNotEmptyObjectAndAllFalse(
   options?: { nullable: boolean },
   validationOptions?: ValidationOptions,
 ) {
-  return function (object: any, propertyName: string) {
+  return function (object: { key: boolean }, propertyName: string) {
     IsNotEmptyObject(options, validationOptions)(object, propertyName);
     registerDecorator({
       name: 'isNotEmptyObjectAndAllFalse',

--- a/src/mentor-reviews/dtos/create-mentor-review-request-body.dto.ts
+++ b/src/mentor-reviews/dtos/create-mentor-review-request-body.dto.ts
@@ -1,13 +1,9 @@
 import { MentorReviewDto } from './mentor-review.dto';
 import { CreateMentorReviewChecklistRequestBodyDto } from './create-mentor-review-checklist-request-body.dto';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  IsNotEmptyObject,
-  IsOptional,
-  IsString,
-  ValidateNested,
-} from 'class-validator';
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
+import { IsNotEmptyObjectAndAllFalse } from 'src/common/decorators/validators/is-not-empty-object-and-all-false.decorator';
 
 export class CreateMentorReviewRequestBodyDto
   implements Partial<MentorReviewDto>
@@ -18,7 +14,7 @@ export class CreateMentorReviewRequestBodyDto
   })
   @ValidateNested()
   @Type(() => CreateMentorReviewChecklistRequestBodyDto)
-  @IsNotEmptyObject()
+  @IsNotEmptyObjectAndAllFalse()
   createMentorReviewChecklistRequestBodyDto: CreateMentorReviewChecklistRequestBodyDto;
 
   @ApiPropertyOptional({


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
생성된 checklist review에서 그냥 전부 다 false면 에러를 던져주는 예외처리를 해주려 했습니다.
근데 생각해보니까 애초에 받을 때부터 전부 false인지를 검사하는게 로직상 더 낫겠다는 생각이 들어서 custom validator를 만들었습니다.
그렇습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
1. 빈 object인지 검사
2. object 내부의 value가 전부 false인지 검사

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link
https://jw910911.tistory.com/167

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#185 

<!-- 작업한 API (선택) -->
### API