### PR TITLE
modify/#215/modify mentorReview/BoardCount type

### DIFF
--- a/src/mentors/dtos/user-with-image-and-intro.dto.ts
+++ b/src/mentors/dtos/user-with-image-and-intro.dto.ts
@@ -46,6 +46,8 @@ export class UserWithImageAndIntroDto extends PickType(UserForJoinDto, [
     super();
 
     Object.assign(this, userWithImageAndIntroDto);
+    this.mentorReviewCount = Number(userWithImageAndIntroDto.mentorReviewCount);
+    this.mentorBoardCount = Number(userWithImageAndIntroDto.mentorBoardCount);
     this.rank = userWithImageAndIntroDto.user_rank;
   }
 }

--- a/src/mentors/swagger-decorators/find-all-mentors-and-count.decorator.ts
+++ b/src/mentors/swagger-decorators/find-all-mentors-and-count.decorator.ts
@@ -1,6 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
 import {
-  ApiBearerAuth,
   ApiExtraModels,
   ApiNotFoundResponse,
   ApiOperation,
@@ -15,7 +14,6 @@ export function ApiFindAllMentorsAndCount() {
       summary: '멘토 리스트 pagination',
       description: `page및 limit, 정렬할 필드, 오름차순 내림차순, 필터링할 필드를 클라이언트에게서 받습니다.`,
     }),
-    ApiBearerAuth('access-token'),
     ApiResponse({
       status: 200,
       description: '멘토 리스트 성공적으로 불러옴.',


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
mentors GET api 불러올 때 같이 딸려오는 mentorReviewCount, mentorBoardCount 프로퍼티의 type이 string이어서 number 타입으로 변환 해줬습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
mentor-list api 불러올 때 같이 딸려오는 mentorReviewCount, mentorBoardCount 프로퍼티의 type이 string이어서 number 타입으로 변환 해줬습니다.
추가로 BearerAuth도 뺐습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#215 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /mentors | 멘토 페이지네이션 | 수정                   |
