### PR TITLE
modify/#236/modify help you comments pagination api

### DIFF
--- a/src/boards/repository/help.me.board.repository.ts
+++ b/src/boards/repository/help.me.board.repository.ts
@@ -114,6 +114,7 @@ export class HelpMeBoardRepository {
   }
 
   findAllHelpYouCommentsByQueryBuilder(
+    helpMeBoardId: number,
     skip: number,
     pageSize: number,
     orderField: HelpYouCommentOrderField,
@@ -140,7 +141,8 @@ export class HelpMeBoardRepository {
         'userImage.imageUrl',
         'userIntro.shortIntro',
         'userIntro.career',
-      ]);
+      ])
+      .where({ helpMeBoardId });
 
     this.queryBuilderHelper.buildWherePropForFind(
       queryBuilder,

--- a/src/boards/services/help.me.board.service.ts
+++ b/src/boards/services/help.me.board.service.ts
@@ -98,6 +98,7 @@ export class HelpMeBoardService {
 
     const [helpYouComments, totalCount] =
       await this.helpMeBoardRepository.findAllHelpYouCommentsByQueryBuilder(
+        helpMeBoard.id,
         skip,
         pageSize,
         orderField,


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
도와줄게요 댓글 pagination api가 param으로 받는 boardId에 대해 조건을 걸지 않아서 모든 도와주세요 게시글의 댓글을 다 불러왔던 문제를 수정했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#236 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /help-me-boards/{helpMeBoardId}/help-you-comments | 도와줄게요 댓글 pagination | 수정                   |
