### PR TITLE
Modify/#260/use websocket server

### DIFF
--- a/src/chat/events/events.gateway.ts
+++ b/src/chat/events/events.gateway.ts
@@ -24,8 +24,8 @@ import { SocketException } from '../exceptions/socket.exception';
 export class EventsGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
 {
-  constructor(private chatService: ChatService) {}
-  @WebSocketServer() public server: Server;
+  constructor(private readonly chatService: ChatService) {}
+  @WebSocketServer() private readonly server: Server;
 
   @SubscribeMessage('test')
   handleTest(@MessageBody() data: string) {
@@ -74,12 +74,8 @@ export class EventsGateway
 
       const stringChatRoomId = String(chatRoom._id);
 
-      await socket.join(stringChatRoomId);
+      socket.join(stringChatRoomId);
       console.log('join', socket.nsp.name, stringChatRoomId);
-
-      socket
-        .to(stringChatRoomId)
-        .emit('join', `join ${socket.nsp.name} ${stringChatRoomId}`);
     }
   }
 
@@ -106,10 +102,11 @@ export class EventsGateway
   @SubscribeMessage('message')
   async handleMessage(
     @MessageBody() postChatDto: PostChatDto,
-    @ConnectedSocket() socket: Socket,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    @ConnectedSocket() _socket: Socket,
   ) {
     const returnedChat = await this.chatService.createChat(postChatDto);
-    socket.to(postChatDto.roomId.toString()).emit('message', returnedChat);
+    this.server.to(postChatDto.roomId.toString()).emit('message', returnedChat);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
기존에 채팅을 보낸 사람은 생성된 채팅을 보지 못하고 수신한 사람만 확인할 수 있었던 오류가 있었고 수정했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
connected된 socket이 아닌 websocket의 server을 이용해서 emit을 해야 발신자에게도 포함돼서 메세지가 수신되어 보여집니다. 

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link
https://stackoverflow.com/questions/24100218/socket-io-send-packet-to-sender-only

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#260 

<!-- 작업한 API (선택) -->