### PR TITLE
Feat/#275/add filter for mentor review pagination

### DIFF
--- a/src/boards/dto/helpMeBoard/help-me-board-page-query.dto.ts
+++ b/src/boards/dto/helpMeBoard/help-me-board-page-query.dto.ts
@@ -3,8 +3,9 @@ import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 import { PageQueryDto } from '@src/common/dto/page-query.dto';
 import { IsPositiveInt } from '@src/common/decorators/validators/is-positive-int.decorator';
 import { HelpMeBoardOrderField } from '@src/boards/constants/help-me-board-order-field.enum';
-import { ParseOptionalBoolean } from '@src/common/transformers/parse-optional-boolean.transformer';
 import { SortOrder } from '@src/common/constants/sort-order.enum';
+import { stringToBoolean } from '@src/common/decorators/transformer/string-to-boolean.transformer';
+import { Transform } from 'class-transformer';
 
 export class HelpMeBoardPageQueryDto extends PageQueryDto {
   @ApiPropertyOptional({
@@ -54,7 +55,7 @@ export class HelpMeBoardPageQueryDto extends PageQueryDto {
   })
   @IsOptional()
   @IsBoolean()
-  @ParseOptionalBoolean()
+  @Transform(stringToBoolean)
   loadOnlyPullingUp: boolean = false;
 
   @ApiProperty({

--- a/src/boards/dto/mentorBoard/mentor-board-page-query.dto.ts
+++ b/src/boards/dto/mentorBoard/mentor-board-page-query.dto.ts
@@ -4,8 +4,9 @@ import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 import { MentorBoardOrderField } from '@src/boards/constants/mentor-board-order-field.enum';
 import { PageQueryDto } from '@src/common/dto/page-query.dto';
 import { IsPositiveInt } from '@src/common/decorators/validators/is-positive-int.decorator';
-import { ParseOptionalBoolean } from '@src/common/transformers/parse-optional-boolean.transformer';
 import { SortOrder } from '@src/common/constants/sort-order.enum';
+import { Transform } from 'class-transformer';
+import { stringToBoolean } from '@src/common/decorators/transformer/string-to-boolean.transformer';
 
 export class MentorBoardPageQueryDto extends PageQueryDto {
   @ApiPropertyOptional({
@@ -54,7 +55,7 @@ export class MentorBoardPageQueryDto extends PageQueryDto {
   })
   @IsOptional()
   @IsBoolean()
-  @ParseOptionalBoolean()
+  @Transform(stringToBoolean)
   loadOnlyPopular: boolean = false;
 
   @ApiProperty({

--- a/src/common/constants/optional-boolean-mapper.ts
+++ b/src/common/constants/optional-boolean-mapper.ts
@@ -1,5 +1,0 @@
-export const optionalBooleanMapper = new Map([
-  ['undefined', undefined],
-  ['true', true],
-  ['false', false],
-]);

--- a/src/common/constants/query-page-size.ts
+++ b/src/common/constants/query-page-size.ts
@@ -1,0 +1,5 @@
+export const QUERY_PAGE_SIZE = {
+  MIN: 1,
+  MAX: 100,
+  DEFAULT: 5,
+} as const;

--- a/src/common/decorators/transformer/string-to-boolean.spec.ts
+++ b/src/common/decorators/transformer/string-to-boolean.spec.ts
@@ -1,0 +1,23 @@
+import { stringToBoolean } from '@src/common/decorators/transformer/string-to-boolean.transformer';
+
+describe(stringToBoolean.name, () => {
+  it('BooleanString 외의 값이 들어왔을 때', () => {
+    expect(stringToBoolean({ value: '' })).toBe('');
+  });
+
+  it('string type의 1이 들어 왔을 때', () => {
+    expect(stringToBoolean({ value: '1' })).toBe(true);
+  });
+
+  it('string type의 true가 들어 왔을 때', () => {
+    expect(stringToBoolean({ value: 'true' })).toBe(true);
+  });
+
+  it('string type의 0이 들어 왔을 때', () => {
+    expect(stringToBoolean({ value: '0' })).toBe(false);
+  });
+
+  it('string type의 false이 들어 왔을 때', () => {
+    expect(stringToBoolean({ value: 'false' })).toBe(false);
+  });
+});

--- a/src/common/decorators/transformer/string-to-boolean.transformer.ts
+++ b/src/common/decorators/transformer/string-to-boolean.transformer.ts
@@ -1,0 +1,11 @@
+export function stringToBoolean({ value }) {
+  if (value === 'true' || value === '1') {
+    return true;
+  }
+
+  if (value === 'false' || value === '0') {
+    return false;
+  }
+
+  return value;
+}

--- a/src/common/dto/page-query.dto.ts
+++ b/src/common/dto/page-query.dto.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { QUERY_PAGE_SIZE } from '@src/common/constants/query-page-size';
 import { IsPositiveInt } from '@src/common/decorators/validators/is-positive-int.decorator';
-import { IsOptional } from 'class-validator';
+import { IsOptional, Max } from 'class-validator';
 
 export class PageQueryDto {
   @ApiPropertyOptional({
@@ -15,10 +16,12 @@ export class PageQueryDto {
 
   @ApiPropertyOptional({
     description: '검색할 페이지 size',
-    minimum: 1,
-    default: 5,
+    minimum: QUERY_PAGE_SIZE.MIN,
+    maximum: QUERY_PAGE_SIZE.MAX,
+    default: QUERY_PAGE_SIZE.DEFAULT,
   })
   @IsOptional()
   @IsPositiveInt()
-  pageSize: number = 5;
+  @Max(QUERY_PAGE_SIZE.MAX)
+  pageSize: number = QUERY_PAGE_SIZE.DEFAULT;
 }

--- a/src/common/transformers/parse-optional-boolean.transformer.ts
+++ b/src/common/transformers/parse-optional-boolean.transformer.ts
@@ -1,5 +1,0 @@
-import { optionalBooleanMapper } from '@src/common/constants/optional-boolean-mapper';
-import { Transform } from 'class-transformer';
-
-export const ParseOptionalBoolean = (): PropertyDecorator =>
-  Transform(({ value }) => optionalBooleanMapper.get(value));

--- a/src/mentors/mentor-reviews/dtos/mentor-review-page-query-dto.ts
+++ b/src/mentors/mentor-reviews/dtos/mentor-review-page-query-dto.ts
@@ -1,10 +1,12 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 import { PageQueryDto } from '@src/common/dto/page-query.dto';
 import { SortOrder } from '@src/common/constants/sort-order.enum';
 import { IsPositiveInt } from '@src/common/decorators/validators/is-positive-int.decorator';
 import { MentorReviewOrderField } from '@src/mentors/mentor-reviews/constants/mentor-review-order-field.enum';
+import { Transform } from 'class-transformer';
+import { stringToBoolean } from '@src/common/decorators/transformer/string-to-boolean.transformer';
 
 export class MentorReviewPageQueryDto extends PageQueryDto {
   @ApiPropertyOptional({
@@ -22,6 +24,86 @@ export class MentorReviewPageQueryDto extends PageQueryDto {
   @IsOptional()
   @IsPositiveInt()
   menteeId?: number;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 잘가르쳐요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isGoodWork?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 깔끔해요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isClear?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 답변이 빨라요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isQuick?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 정확해요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isAccurate?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 친절해요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isKindness?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 재밌어요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isFun?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 알차요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isInformative?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 아쉬워요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isBad?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 답답해요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isStuffy?: boolean;
+
+  @ApiPropertyOptional({
+    description: '멘토 리뷰 체크리스트 이해가 잘돼요 필터링',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(stringToBoolean)
+  isUnderstandWell?: boolean;
 
   @ApiPropertyOptional({
     description: '리뷰 내용 필터링',

--- a/src/mentors/mentor-reviews/mentor-reviews.module.ts
+++ b/src/mentors/mentor-reviews/mentor-reviews.module.ts
@@ -8,6 +8,7 @@ import { MentorReviewsController } from '@src/mentors/mentor-reviews/controllers
 import { MentorReview } from '@src/mentors/mentor-reviews/entities/mentor-review.entity';
 import { MentorReviewRepository } from '@src/mentors/mentor-reviews/repositories/mentor-review.repository';
 import { MentorReviewsService } from '@src/mentors/mentor-reviews/services/mentor-reviews.service';
+import { QueryHelper } from '@src/helpers/query.helper';
 
 @Module({
   imports: [
@@ -17,6 +18,6 @@ import { MentorReviewsService } from '@src/mentors/mentor-reviews/services/mento
     TotalCountModule,
   ],
   controllers: [MentorReviewsController],
-  providers: [MentorReviewsService, MentorReviewRepository],
+  providers: [MentorReviewsService, MentorReviewRepository, QueryHelper],
 })
 export class MentorReviewsModule {}

--- a/src/mentors/mentor-reviews/repositories/mentor-review.repository.ts
+++ b/src/mentors/mentor-reviews/repositories/mentor-review.repository.ts
@@ -1,7 +1,5 @@
-import { EntityManager, FindOneOptions, Like, UpdateResult } from 'typeorm';
-import { SortOrder } from '@src/common/constants/sort-order.enum';
+import { EntityManager, FindOneOptions, UpdateResult } from 'typeorm';
 import { Injectable } from '@nestjs/common';
-import { MentorReviewOrderField } from '@src/mentors/mentor-reviews/constants/mentor-review-order-field.enum';
 import { MentorReviewsItemResponseDto } from '@src/mentors/mentor-reviews/dtos/mentor-reviews-item-response.dto';
 import { MentorReview } from '@src/mentors/mentor-reviews/entities/mentor-review.entity';
 
@@ -25,12 +23,8 @@ export class MentorReviewRepository {
   findMentorReviews(
     skip: number,
     pageSize: number,
-    id: number,
-    menteeId: number,
-    mentorId: number,
-    review: string,
-    orderField: MentorReviewOrderField,
-    sortOrder: SortOrder,
+    where: Record<string, any>,
+    order: Record<string, any>,
   ): Promise<[MentorReviewsItemResponseDto[], number]> {
     return this.entityManager.getRepository(MentorReview).findAndCount({
       select: {
@@ -58,24 +52,18 @@ export class MentorReviewRepository {
         isInformative: true,
         isBad: true,
         isStuffy: true,
+        isUnderstandWell: true,
         createdAt: true,
         updatedAt: true,
       },
-      where: {
-        mentorId,
-        ...(id ? { id } : {}),
-        ...(menteeId ? { menteeId } : {}),
-        ...(review ? { review: Like(`%${review}%`) } : {}),
-      },
+      where,
       relations: {
         mentee: {
           userImage: true,
           userIntro: true,
         },
       },
-      order: {
-        [orderField]: sortOrder,
-      },
+      order,
       skip,
       take: pageSize,
     });

--- a/src/mentors/mentor-reviews/services/mentor-reviews.service.ts
+++ b/src/mentors/mentor-reviews/services/mentor-reviews.service.ts
@@ -36,6 +36,20 @@ export class MentorReviewsService {
     const { review, createMentorReviewChecklistRequestBodyDto } =
       createMentorReviewRequestBodyDto;
 
+    let trueCount = 0;
+
+    for (const key in createMentorReviewChecklistRequestBodyDto) {
+      if (createMentorReviewChecklistRequestBodyDto[key]) {
+        trueCount++;
+      }
+
+      if (trueCount > 3) {
+        throw new BadRequestException(
+          "Can't select more than four checklists.",
+        );
+      }
+    }
+
     const existMentor = await this.userService.findOneByOrNotFound({
       select: {
         id: true,

--- a/src/mentors/mentor-reviews/swagger-decorators/create-mentor-review.decorator.ts
+++ b/src/mentors/mentor-reviews/swagger-decorators/create-mentor-review.decorator.ts
@@ -64,6 +64,7 @@ export function ApiCreateMentorReview() {
                   'createMentorReviewChecklistRequestBodyDto.isInformative must be a boolean value',
                   'createMentorReviewChecklistRequestBodyDto.isBad must be a boolean value',
                   'createMentorReviewChecklistRequestBodyDto.isStuffy must be a boolean value',
+                  "Can't select more than four checklists.",
                   'property [허용하지 않은 데이터] should not exist',
                 ],
                 error: 'Bad Request',


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
멘토리뷰 페이지네이션 api에서 체크리스트 필터링을 추가했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
boolean transform 방식을 좀 변경했고 테스트 코드도 추가했습니다.
멘토리뷰 pagination 기존 로직을 쿼리 헬퍼를 이용하는 방식으로 수정했습니다.
기존의 pageSize의 min, max값 및 default값을 constant를 만들어서 관리하는 방식으로 수정했습니다.(좀 더 명확하게 관리하기 위해)
멘토리뷰 생성 시 체크리스트 4개 이상은 들어오지 못하도록 하는 validation 로직을 만들었습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#275 
