### PR TITLE
setting/#314/add allow origin in cors setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,10 +34,15 @@ async function bootstrap() {
      */
     origin:
       process.env.NODE_ENV === 'production'
-        ? [process.env.FRONT_PRODUCTION_DOMAIN, process.env.FRONT_LOCAL_DOMAIN]
+        ? [
+            process.env.FRONT_PRODUCTION_DOMAIN,
+            process.env.FRONT_PRODUCTION_WWW_DOMAIN,
+            process.env.FRONT_LOCAL_DOMAIN,
+          ]
         : 'development'
           ? [
               process.env.FRONT_DEVELOPMENT_DOMAIN,
+              process.env.FRONT_DEVELOPMENT_WWW_DOMAIN,
               process.env.FRONT_LOCAL_DOMAIN,
             ]
           : true, // 또는 특정 도메인을 설정


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
cors 세팅에서 허용하는 origin중에 프론트의 www 도메인도 추가합니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
cors 세팅에서 허용하는 origin중에 프론트의 www 도메인도 추가합니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#314 
