### PR TITLE
Deploy/#338/isolate server environmen

### DIFF
--- a/src/entities/Badge.ts
+++ b/src/entities/Badge.ts
@@ -1,7 +1,7 @@
+import { UserBadge } from '@src/entities/UserBadge';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { UserBadge } from './UserBadge';
 
-@Entity('badge', { schema: 'ma6_menbosha_db' })
+@Entity('badge')
 export class Badge {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/BannedUser.ts
+++ b/src/entities/BannedUser.ts
@@ -1,3 +1,4 @@
+import { User } from '@src/entities/User';
 import {
   Column,
   Entity,
@@ -6,11 +7,10 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 
 @Index('fk_banned_user_ban_user_id', ['banUserId'], {})
 @Index('fk_banned_user_banned_user_id', ['bannedUserId'], {})
-@Entity('banned_user', { schema: 'ma6_menbosha_db' })
+@Entity('banned_user')
 export class BannedUser {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/Category.ts
+++ b/src/entities/Category.ts
@@ -1,10 +1,10 @@
+import { HelpMeBoard } from '@src/entities/HelpMeBoard';
+import { MentorBoard } from '@src/entities/MentorBoard';
+import { User } from '@src/entities/User';
+import { UserRanking } from '@src/entities/UserRanking';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { HelpMeBoard } from './HelpMeBoard';
-import { MentorBoard } from './MentorBoard';
-import { User } from './User';
-import { UserRanking } from './UserRanking';
 
-@Entity('category', { schema: 'ma6_menbosha_db' })
+@Entity('category')
 export class Category {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/HelpMeBoard.ts
+++ b/src/entities/HelpMeBoard.ts
@@ -1,3 +1,7 @@
+import { Category } from '@src/entities/Category';
+import { HelpMeBoardImage } from '@src/entities/HelpMeBoardImage';
+import { HelpYouComment } from '@src/entities/HelpYouComment';
+import { User } from '@src/entities/User';
 import {
   Column,
   DeleteDateColumn,
@@ -8,15 +12,11 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { Category } from './Category';
-import { User } from './User';
-import { HelpMeBoardImage } from './HelpMeBoardImage';
-import { HelpYouComment } from './HelpYouComment';
 
 @Index('FK_help_me_board_category_id', ['categoryId'], {})
 @Index('FK_help_me_board_user_id', ['userId'], {})
 @Index('IDX_fulltext_head_body', ['head', 'body'], { fulltext: true })
-@Entity('help_me_board', { schema: 'ma6_menbosha_db' })
+@Entity('help_me_board')
 export class HelpMeBoard {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/HelpMeBoardImage.ts
+++ b/src/entities/HelpMeBoardImage.ts
@@ -1,3 +1,4 @@
+import { HelpMeBoard } from '@src/entities/HelpMeBoard';
 import {
   Column,
   Entity,
@@ -6,10 +7,9 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { HelpMeBoard } from './HelpMeBoard';
 
 @Index('FK_help_me_board_image_help_me_board_id', ['helpMeBoardId'], {})
-@Entity('help_me_board_image', { schema: 'ma6_menbosha_db' })
+@Entity('help_me_board_image')
 export class HelpMeBoardImage {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/HelpYouComment.ts
+++ b/src/entities/HelpYouComment.ts
@@ -1,3 +1,5 @@
+import { HelpMeBoard } from '@src/entities/HelpMeBoard';
+import { User } from '@src/entities/User';
 import {
   Column,
   DeleteDateColumn,
@@ -7,12 +9,10 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { HelpMeBoard } from './HelpMeBoard';
-import { User } from './User';
 
 @Index('FK_help_you_comment_help_me_board_id', ['helpMeBoardId'], {})
 @Index('FK_help_you_comment_user_id', ['userId'], {})
-@Entity('help_you_comment', { schema: 'ma6_menbosha_db' })
+@Entity('help_you_comment')
 export class HelpYouComment {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/MentorBoard.ts
+++ b/src/entities/MentorBoard.ts
@@ -1,3 +1,7 @@
+import { Category } from '@src/entities/Category';
+import { MentorBoardImage } from '@src/entities/MentorBoardImage';
+import { MentorBoardLike } from '@src/entities/MentorBoardLike';
+import { User } from '@src/entities/User';
 import {
   Column,
   DeleteDateColumn,
@@ -8,15 +12,11 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { Category } from './Category';
-import { User } from './User';
-import { MentorBoardImage } from './MentorBoardImage';
-import { MentorBoardLike } from './MentorBoardLike';
 
 @Index('FK_mentor_board_category_id', ['categoryId'], {})
 @Index('FK_mentor_board_user_id', ['userId'], {})
 @Index('IDX_fulltext_head_body', ['head', 'body'], { fulltext: true })
-@Entity('mentor_board', { schema: 'ma6_menbosha_db' })
+@Entity('mentor_board')
 export class MentorBoard {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/MentorBoardImage.ts
+++ b/src/entities/MentorBoardImage.ts
@@ -1,3 +1,4 @@
+import { MentorBoard } from '@src/entities/MentorBoard';
 import {
   Column,
   Entity,
@@ -6,10 +7,9 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { MentorBoard } from './MentorBoard';
 
 @Index('FK_mentor_board_image_mentor_board_id', ['mentorBoardId'], {})
-@Entity('mentor_board_image', { schema: 'ma6_menbosha_db' })
+@Entity('mentor_board_image')
 export class MentorBoardImage {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/MentorBoardLike.ts
+++ b/src/entities/MentorBoardLike.ts
@@ -1,3 +1,5 @@
+import { MentorBoard } from '@src/entities/MentorBoard';
+import { User } from '@src/entities/User';
 import {
   Column,
   Entity,
@@ -6,12 +8,10 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { MentorBoard } from './MentorBoard';
-import { User } from './User';
 
 @Index('FK_mentor_board_like_mentor_board_id', ['parentId'], {})
 @Index('FK_mentor_board_like_user_id', ['userId'], {})
-@Entity('mentor_board_like', { schema: 'ma6_menbosha_db' })
+@Entity('mentor_board_like')
 export class MentorBoardLike {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/MentorReview.ts
+++ b/src/entities/MentorReview.ts
@@ -7,12 +7,12 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 import { BooleanTransformer } from '@src/entities/transformers/boolean.transformer';
+import { User } from '@src/entities/User';
 
 @Index('FK_mentor_review_mentee_id', ['menteeId'], {})
 @Index('FK_mentor_review_mentor_id', ['mentorId'], {})
-@Entity('mentor_review', { schema: 'ma6_menbosha_db' })
+@Entity('mentor_review')
 export class MentorReview {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/MentorReviewChecklistCount.ts
+++ b/src/entities/MentorReviewChecklistCount.ts
@@ -1,3 +1,4 @@
+import { User } from '@src/entities/User';
 import {
   Column,
   DeleteDateColumn,
@@ -7,12 +8,11 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 
 @Index('UQ_mentor_review_checklist_count_mentor_id', ['mentorId'], {
   unique: true,
 })
-@Entity('mentor_review_checklist_count', { schema: 'ma6_menbosha_db' })
+@Entity('mentor_review_checklist_count')
 export class MentorReviewChecklistCount {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/Migrations.ts
+++ b/src/entities/Migrations.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
-@Entity('migrations', { schema: 'ma6_menbosha_db' })
+@Entity('migrations')
 export class Migrations {
   @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
   id: number;

--- a/src/entities/Report.ts
+++ b/src/entities/Report.ts
@@ -7,12 +7,12 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 import { ReportType } from '@src/reports/constants/report-type.enum';
+import { User } from '@src/entities/User';
 
 @Index('FK_report_report_user_id', ['reportUserId'], {})
 @Index('FK_report_reported_user_id', ['reportedUserId'], {})
-@Entity('report', { schema: 'ma6_menbosha_db' })
+@Entity('report')
 export class Report {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/Token.ts
+++ b/src/entities/Token.ts
@@ -1,3 +1,4 @@
+import { User } from '@src/entities/User';
 import {
   Column,
   Entity,
@@ -6,10 +7,9 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 
 @Index('UQ_token_user_id', ['userId'], { unique: true })
-@Entity('token', { schema: 'ma6_menbosha_db' })
+@Entity('token')
 export class Token {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/TotalCount.ts
+++ b/src/entities/TotalCount.ts
@@ -1,3 +1,4 @@
+import { User } from '@src/entities/User';
 import {
   Column,
   DeleteDateColumn,
@@ -7,10 +8,9 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 
 @Index('UQ_total_count_user_id', ['userId'], { unique: true })
-@Entity('total_count', { schema: 'ma6_menbosha_db' })
+@Entity('total_count')
 export class TotalCount {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -9,31 +9,31 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { BannedUser } from './BannedUser';
-import { HelpMeBoard } from './HelpMeBoard';
-import { HelpYouComment } from './HelpYouComment';
-import { MentorBoard } from './MentorBoard';
-import { MentorBoardLike } from './MentorBoardLike';
-import { MentorReview } from './MentorReview';
-import { MentorReviewChecklistCount } from './MentorReviewChecklistCount';
-import { Report } from './Report';
-import { Token } from './Token';
-import { TotalCount } from './TotalCount';
-import { Category } from './Category';
-import { UserBadge } from './UserBadge';
-import { UserImage } from './UserImage';
-import { UserIntro } from './UserIntro';
-import { UserRanking } from './UserRanking';
 import { UserStatus } from '@src/users/constants/user-status.enum';
 import { UserRole } from '@src/users/constants/user-role.enum';
 import { UserProvider } from '@src/auth/enums/user-provider.enum';
 import { BooleanTransformer } from '@src/entities/transformers/boolean.transformer';
+import { BannedUser } from '@src/entities/BannedUser';
+import { Category } from '@src/entities/Category';
+import { HelpMeBoard } from '@src/entities/HelpMeBoard';
+import { HelpYouComment } from '@src/entities/HelpYouComment';
+import { MentorBoard } from '@src/entities/MentorBoard';
+import { MentorBoardLike } from '@src/entities/MentorBoardLike';
+import { MentorReview } from '@src/entities/MentorReview';
+import { MentorReviewChecklistCount } from '@src/entities/MentorReviewChecklistCount';
+import { TotalCount } from '@src/entities/TotalCount';
+import { UserBadge } from '@src/entities/UserBadge';
+import { UserImage } from '@src/entities/UserImage';
+import { UserIntro } from '@src/entities/UserIntro';
+import { UserRanking } from '@src/entities/UserRanking';
+import { Report } from '@src/entities/Report';
+import { Token } from '@src/entities/Token';
 
 @Index('FK_user_activity_category_id', ['activityCategoryId'], {})
 @Index('FK_user_hope_category_id', ['hopeCategoryId'], {})
 @Index('IDX_fulltext_name', ['name'], { fulltext: true })
 @Index('UQ_user_unique_id', ['uniqueId'], { unique: true })
-@Entity('user', { schema: 'ma6_menbosha_db' })
+@Entity('user')
 export class User {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/UserBadge.ts
+++ b/src/entities/UserBadge.ts
@@ -1,3 +1,5 @@
+import { Badge } from '@src/entities/Badge';
+import { User } from '@src/entities/User';
 import {
   Column,
   Entity,
@@ -6,12 +8,10 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { Badge } from './Badge';
-import { User } from './User';
 
 @Index('FK_user_badge_badge_id', ['badgeId'], {})
 @Index('FK_user_badge_user_id', ['userId'], {})
-@Entity('user_badge', { schema: 'ma6_menbosha_db' })
+@Entity('user_badge')
 export class UserBadge {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/UserImage.ts
+++ b/src/entities/UserImage.ts
@@ -1,3 +1,4 @@
+import { User } from '@src/entities/User';
 import {
   Column,
   Entity,
@@ -6,10 +7,9 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 
 @Index('UQ_user_image_user_id', ['userId'], { unique: true })
-@Entity('user_image', { schema: 'ma6_menbosha_db' })
+@Entity('user_image')
 export class UserImage {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/UserIntro.ts
+++ b/src/entities/UserIntro.ts
@@ -1,3 +1,4 @@
+import { User } from '@src/entities/User';
 import {
   Column,
   Entity,
@@ -6,10 +7,9 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { User } from './User';
 
 @Index('UQ_user_intro_user_id', ['userId'], { unique: true })
-@Entity('user_intro', { schema: 'ma6_menbosha_db' })
+@Entity('user_intro')
 export class UserIntro {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/entities/UserRanking.ts
+++ b/src/entities/UserRanking.ts
@@ -1,3 +1,5 @@
+import { Category } from '@src/entities/Category';
+import { User } from '@src/entities/User';
 import {
   Column,
   DeleteDateColumn,
@@ -8,12 +10,10 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { Category } from './Category';
-import { User } from './User';
 
 @Index('FK_user_ranking_activity_category_id', ['activityCategoryId'], {})
 @Index('UQ_user_ranking_user_id', ['userId'], { unique: true })
-@Entity('user_ranking', { schema: 'ma6_menbosha_db' })
+@Entity('user_ranking')
 export class UserRanking {
   @PrimaryGeneratedColumn({
     type: 'int',

--- a/src/migrations/badge/1709815357848-badge.ts
+++ b/src/migrations/badge/1709815357848-badge.ts
@@ -37,7 +37,7 @@ export class Badge1709815357848 implements MigrationInterface {
     };
 
     await queryRunner.manager
-      .getRepository(Badge)
+      .getRepository('badge')
       .upsert(
         [
           nameMemoFactory('친절한 멘토씨', '친절해요', 5),

--- a/src/migrations/category/1709815316486-category.ts
+++ b/src/migrations/category/1709815316486-category.ts
@@ -1,4 +1,3 @@
-import { Category } from '@src/entities/Category';
 import { generatePrimaryColumn } from '@src/migrations/__utils/util';
 import { MigrationInterface, QueryRunner, Table, TableColumn } from 'typeorm';
 
@@ -20,7 +19,7 @@ export class Category1709815316486 implements MigrationInterface {
       }),
     );
 
-    await queryRunner.manager.getRepository(Category).upsert(
+    await queryRunner.manager.getRepository('category').upsert(
       [
         {
           name: '전체',


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
마이그레이션 중에 엔티티의 메타데이터를 찾아오지 못하는 에러가 있어서 조금 수정했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
entity파일들의 import 경로도 절대 경로로 수정해줬고, schema 옵션 땠습니다.
메타데이터를 받아오지 못하는 이유는 아마 엔티티 내부에 아직 생성되지 않은 테이블들과의 Relation때문?인지 단순 typeorm의 버그인지는 잘 모르겠습니다만 일단 문자열로 지정해줬습니다.
이게 생성되지 않은 엔티티들과의 relation 때문이라면 이전에 db의 테이블들을 전부 밀고 migration을 실행 시켰을 때도 에러가 났어야 하는데 나지 않았어서 그냥 뭔가 버그 + 숙련도 이슈 문제 아닐까 생각합니다..

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#338 