### PR TITLE
bugfix/#358/modify bug logic

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -180,12 +180,9 @@ export class AuthService implements AuthServiceInterface {
          * 방법 3. 자동 복원(현재)
          */
         if (deletedAt && status === UserStatus.INACTIVE) {
-          user.status = UserStatus.ACTIVE;
-          user.deletedAt = null;
-
           const updateResult = await this.userService.updateUser(user.id, {
-            status: user.status,
-            deletedAt: user.deletedAt,
+            status: UserStatus.ACTIVE,
+            deletedAt: null,
           });
 
           if (!updateResult.affected) {

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -184,7 +184,8 @@ export class AuthService implements AuthServiceInterface {
           user.deletedAt = null;
 
           const updateResult = await this.userService.updateUser(user.id, {
-            ...user,
+            status: user.status,
+            deletedAt: user.deletedAt,
           });
 
           if (!updateResult.affected) {


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
spread 연산자를 사용해서 탈퇴한 유저의 계정을 다시 복구하는 로직이 있었는데 이 부분에서 banned 프로퍼티가 같이 딸려갔던 뿐에서 에러가 발생했습니다. 해당 부분을 해결 했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#358