### PR TITLE
Modify/#354/use cookie to new token

### DIFF
--- a/src/auth/jwt/jwt-auth.guard.ts
+++ b/src/auth/jwt/jwt-auth.guard.ts
@@ -50,7 +50,7 @@ export class RefreshTokenAuthGuard extends AuthGuard('refreshToken') {
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
-    const authorization = request.headers['authorization'];
+    const authorization = request.cookies['refreshToken'];
     if (!authorization) {
       throw new HttpException('jwt must be provided', HttpStatus.BAD_REQUEST);
     }

--- a/src/auth/jwt/jwt.strategy.ts
+++ b/src/auth/jwt/jwt.strategy.ts
@@ -60,7 +60,7 @@ export class RefreshTokenStrategy extends PassportStrategy(
     private readonly appConfigService: AppConfigService,
   ) {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: (req) => req.cookies['refreshToken'],
       ignoreExpiration: false,
       secretOrKey: appConfigService.get<string>(
         ENV_KEY.JWT_REFRESH_TOKEN_SECRET_KEY,
@@ -74,7 +74,7 @@ export class RefreshTokenStrategy extends PassportStrategy(
       throw new HttpException('invalid token type', HttpStatus.BAD_REQUEST);
     }
 
-    const tokenFromRequest = request.headers.authorization.split(' ')[1];
+    const tokenFromRequest = request.cookies['refreshToken'];
     const tokenInRedis = await this.redisService.getToken(
       `${payload.userId}-refreshToken`,
     );

--- a/src/common/interceptors/cookie.interceptor.ts
+++ b/src/common/interceptors/cookie.interceptor.ts
@@ -26,7 +26,7 @@ export class CookieInterceptor implements NestInterceptor {
           });
         }
 
-        // delete data.refreshToken; // refreshToken을 응답에서 삭제
+        delete data.refreshToken; // refreshToken을 응답에서 삭제
         return data;
       }),
     );


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
액세스 토큰 재발급 할 때 cookie에 저장된 refreshToken을 가져와서 재발급하도록 로직 변경했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#354 