### PR TITLE
Deploy/#368/development subdomain setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,20 +21,20 @@ services:
     restart: always
 
   api-nginx-certbot:
-    image: 2swo/back-nginx-certbot
+    image: 2swo/api-back-nginx-certbot
     ports:
       - '80:80'
       - '443:443'
     env_file:
       - .env.nginx-certbot
 
-    # dev-nginx-certbot:
-    # image: 2swo/dev-back-nginx-certbot
-    # ports:
-    #   - '80:80'
-    #   - '443:443'
-    # env_file:
-    #   - .env.nginx-certbot
+  # dev-nginx-certbot: #dev서버 nginx파일
+  # image: 2swo/dev-back-nginx-certbot
+  # ports:
+  #   - '80:80'
+  #   - '443:443'
+  # env_file:
+  #   - .env.nginx-certbot
 
   # mysql 이미지는 따로 dockerfile로 빌드되진 않습니다.
   # version과 port,env파일명,command 참고하시면 될 것 같습니다.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,21 @@ services:
       - '6379:6379'
     restart: always
 
-  nginx-certbot:
+  api-nginx-certbot:
     image: 2swo/back-nginx-certbot
     ports:
       - '80:80'
       - '443:443'
     env_file:
       - .env.nginx-certbot
+
+    # dev-nginx-certbot:
+    # image: 2swo/dev-back-nginx-certbot
+    # ports:
+    #   - '80:80'
+    #   - '443:443'
+    # env_file:
+    #   - .env.nginx-certbot
 
   # mysql 이미지는 따로 dockerfile로 빌드되진 않습니다.
   # version과 port,env파일명,command 참고하시면 될 것 같습니다.

--- a/dockerfile
+++ b/dockerfile
@@ -1,22 +1,22 @@
-# # Node.js 버전을 기반으로 하는 도커 이미지 사용
-# FROM node:18.16.0-alpine AS build
+# Node.js 버전을 기반으로 하는 도커 이미지 사용
+FROM node:18.16.0-alpine AS build
 
-# # 작업 디렉토리 설정
-# WORKDIR /home/app
+# 작업 디렉토리 설정
+WORKDIR /home/app
 
-# # 작업 디렉토리에 내용 복사
-# COPY package*.json ./
+# 작업 디렉토리에 내용 복사
+COPY package*.json ./
 
-# RUN npm ci --only=production && npm cache clean --force
+RUN npm ci --only=production && npm cache clean --force
 
-# # /dist 폴더를 이미지에 복사
-# COPY ./dist ./dist
+# /dist 폴더를 이미지에 복사
+COPY ./dist ./dist
 
-# # 애플리케이션 실행
-# CMD ["npm", "run", "start:prod"]
+# 애플리케이션 실행
+CMD ["npm", "run", "start:prod"]
 
-# # 애플리케이션을 실행할 포트
-# EXPOSE 3000
+# 애플리케이션을 실행할 포트
+EXPOSE 3000
 
 ######################### Redis ##############################
 
@@ -40,22 +40,22 @@
 
 ######################### nginx-certbot ##############################
 
-#nginx 이미지 사용
-FROM nginx:latest
+# #nginx 이미지 사용
+# FROM nginx:latest
 
-#nignx와 certbot 설치
-RUN apt-get update && apt-get install -y certbot python3-certbot-nginx
+# #nignx와 certbot 설치
+# RUN apt-get update && apt-get install -y certbot python3-certbot-nginx
 
-#nginx.conf(설정파일 복사)
-COPY nginx.conf /etc/nginx/nginx.conf
+# #nginx.conf(설정파일 복사)
+# COPY nginx.conf /etc/nginx/nginx.conf
 
-#port
-EXPOSE 80
-EXPOSE 443
+# #port
+# EXPOSE 80
+# EXPOSE 443
 
-#entrypoint.sh 복사, 권한부여
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# #entrypoint.sh 복사, 권한부여
+# COPY entrypoint.sh /entrypoint.sh
+# RUN chmod +x /entrypoint.sh
 
-#컨테이너가 실행될 때 entrypoint.sh 실행
-CMD ["/entrypoint.sh"]
+# #컨테이너가 실행될 때 entrypoint.sh 실행
+# CMD ["/entrypoint.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,22 +1,22 @@
-# Node.js 버전을 기반으로 하는 도커 이미지 사용
-FROM node:18.16.0-alpine AS build
+# # Node.js 버전을 기반으로 하는 도커 이미지 사용
+# FROM node:18.16.0-alpine AS build
 
-# 작업 디렉토리 설정
-WORKDIR /home/app
+# # 작업 디렉토리 설정
+# WORKDIR /home/app
 
-# 작업 디렉토리에 내용 복사
-COPY package*.json ./
+# # 작업 디렉토리에 내용 복사
+# COPY package*.json ./
 
-RUN npm ci --only=production && npm cache clean --force
+# RUN npm ci --only=production && npm cache clean --force
 
-# /dist 폴더를 이미지에 복사
-COPY ./dist ./dist
+# # /dist 폴더를 이미지에 복사
+# COPY ./dist ./dist
 
-# 애플리케이션 실행
-CMD ["npm", "run", "start:prod"]
+# # 애플리케이션 실행
+# CMD ["npm", "run", "start:prod"]
 
-# 애플리케이션을 실행할 포트
-EXPOSE 3000
+# # 애플리케이션을 실행할 포트
+# EXPOSE 3000
 
 ######################### Redis ##############################
 
@@ -40,22 +40,22 @@ EXPOSE 3000
 
 ######################### nginx-certbot ##############################
 
-# #nginx 이미지 사용
-# FROM nginx:latest
+#nginx 이미지 사용
+FROM nginx:latest
 
-# #nignx와 certbot 설치
-# RUN apt-get update && apt-get install -y certbot python3-certbot-nginx
+#nignx와 certbot 설치
+RUN apt-get update && apt-get install -y certbot python3-certbot-nginx
 
-# #nginx.conf(설정파일 복사)
-# COPY nginx.conf /etc/nginx/nginx.conf
+#nginx.conf(설정파일 복사)
+COPY nginx.conf /etc/nginx/nginx.conf
 
-# #port
-# EXPOSE 80
-# EXPOSE 443
+#port
+EXPOSE 80
+EXPOSE 443
 
-# #entrypoint.sh 복사, 권한부여
-# COPY entrypoint.sh /entrypoint.sh
-# RUN chmod +x /entrypoint.sh
+#entrypoint.sh 복사, 권한부여
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-# #컨테이너가 실행될 때 entrypoint.sh 실행
-# CMD ["/entrypoint.sh"]
+#컨테이너가 실행될 때 entrypoint.sh 실행
+CMD ["/entrypoint.sh"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,17 +5,17 @@ events {
 http {
     server {
         listen 80;
-        # server_name api.menbosha.kr; # 베포백서버
-        server_name dev.menbosha.kr; # 개발백서버
+        server_name api.menbosha.kr; # 베포백서버
+        # server_name dev.menbosha.kr; # 개발백서버
         location / {
-            # proxy_pass http://13.124.22.25:3000; # 베포백서버 ipv4
-            proxy_pass http://15.164.222.126:3000; # 개발백서버 ipv4
+            proxy_pass http://13.124.22.25:3000; # 베포백서버 ipv4
+            # proxy_pass http://15.164.222.126:3000; # 개발백서버 ipv4
         }
         location /socket.io/ {
 		    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $host;
-            # proxy_pass http://13.124.22.25:3000; # 베포백서버 ipv4
-            proxy_pass http://15.164.222.126:3000; # 개발백서버 ipv4
+            proxy_pass http://13.124.22.25:3000; # 베포백서버 ipv4
+            # proxy_pass http://15.164.222.126:3000; # 개발백서버 ipv4
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,14 +5,17 @@ events {
 http {
     server {
         listen 80;
-        server_name api.menbosha.kr; # back은 api만 사용
+        # server_name api.menbosha.kr; # 베포백서버
+        server_name dev.menbosha.kr; # 개발백서버
         location / {
-            proxy_pass http://13.124.22.25:3000;
+            # proxy_pass http://13.124.22.25:3000; # 베포백서버 ipv4
+            proxy_pass http://15.164.222.126:3000; # 개발백서버 ipv4
         }
         location /socket.io/ {
 		    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $host;
-            proxy_pass http://13.124.22.25:3000;
+            # proxy_pass http://13.124.22.25:3000; # 베포백서버 ipv4
+            proxy_pass http://15.164.222.126:3000; # 개발백서버 ipv4
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
개발 백서버 <-> vercel 프론트 개발서버 간 https통신을 위해 nginx-certbot 컨테이너를 추가했습니다.

특이사항으로는, compose에 주석처리된 부분과 같이, 앞에 dev, api등으로 어느 서버에서의 사용인지 명시해놨습니다.
각 nginx.conf파일과 env에 따로 주석으로 적용해놨습니다. 만약 문제가 있을 시 제가 확인하겠지만 혹여나 해서 남겨놨습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#368 
<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /api/user | 유저 정보 조회 | 추가                   |
